### PR TITLE
Add codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Rancher/k3s will be a suggested reviewer for all pull requests
+* @rancher/k3s


### PR DESCRIPTION
This should add the rancher/k3s group to all pull requests by default.