### PR TITLE
fix: remove version constraints

### DIFF
--- a/examples/advanced/versions.tf
+++ b/examples/advanced/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.5.0, < 1.6"
+  required_version = ">= 1.5.0"
   required_providers {
     local = {
       source  = "hashicorp/local"

--- a/examples/basic/versions.tf
+++ b/examples/basic/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.5.0, < 1.6"
+  required_version = ">= 1.5.0"
   required_providers {
     local = {
       source  = "hashicorp/local"

--- a/examples/easy/versions.tf
+++ b/examples/easy/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.5.0, < 1.6"
+  required_version = ">= 1.5.0"
   required_providers {
     local = {
       source  = "hashicorp/local"

--- a/examples/typetest/versions.tf
+++ b/examples/typetest/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.5.0, < 1.6"
+  required_version = ">= 1.5.0"
   required_providers {
     local = {
       source  = "hashicorp/local"

--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.5.0, < 1.6"
+  required_version = ">= 1.5.0"
   required_providers {
     local = {
       source  = "hashicorp/local"


### PR DESCRIPTION
Don't constrain the Terraform version to only use the non BUSL versions.
Users are responsible for how they use our module and whether they are in compliance with their use of Terraform.